### PR TITLE
[optimize] try to decrease step size on error

### DIFF
--- a/GPclust/collapsed_vb.py
+++ b/GPclust/collapsed_vb.py
@@ -123,6 +123,7 @@ class CollapsedVB(GPy.core.Model):
                 try:
                     self.set_vb_param(phi_old + step_length*searchDir)
                     bound = self.bound()
+                    step_length /= 2.
                 except LinAlgError:
                     import warnings
                     warnings.warn("Caught LinalgError in setting variational parameters, trying to continue with old parameter settings", LinAlgWarning)

--- a/GPclust/collapsed_vb.py
+++ b/GPclust/collapsed_vb.py
@@ -134,7 +134,7 @@ class CollapsedVB(GPy.core.Model):
 
 
             if verbose:
-                print '\riteration '+str(iteration)+' bound='+str(bound) + ' grad='+str(squareNorm) + ', beta='+str(beta),  + ', step_size='+str(step_size), 
+                print '\riteration '+str(iteration)+' bound='+str(bound) + ' grad='+str(squareNorm) + ', beta='+str(beta) + ', step_size='+str(step_size), 
                 sys.stdout.flush()
 
             # converged yet? try the parameters if so

--- a/GPclust/collapsed_vb.py
+++ b/GPclust/collapsed_vb.py
@@ -134,7 +134,7 @@ class CollapsedVB(GPy.core.Model):
 
 
             if verbose:
-                print '\riteration '+str(iteration)+' bound='+str(bound) + ' grad='+str(squareNorm) + ', beta='+str(beta),
+                print '\riteration '+str(iteration)+' bound='+str(bound) + ' grad='+str(squareNorm) + ', beta='+str(beta),  + ', step_size='+str(step_size), 
                 sys.stdout.flush()
 
             # converged yet? try the parameters if so

--- a/GPclust/collapsed_vb.py
+++ b/GPclust/collapsed_vb.py
@@ -134,7 +134,7 @@ class CollapsedVB(GPy.core.Model):
 
 
             if verbose:
-                print '\riteration '+str(iteration)+' bound='+str(bound) + ' grad='+str(squareNorm) + ', beta='+str(beta) + ', step_size='+str(step_size), 
+                print '\riteration '+str(iteration)+' bound='+str(bound) + ' grad='+str(squareNorm) + ', beta='+str(beta) + ', step_length='+str(step_length), 
                 sys.stdout.flush()
 
             # converged yet? try the parameters if so

--- a/GPclust/collapsed_vb.py
+++ b/GPclust/collapsed_vb.py
@@ -113,6 +113,7 @@ class CollapsedVB(GPy.core.Model):
                 bound = self.bound()
             except LinAlgError:
                 self.set_vb_param(phi_old)
+                step_length /= 2.
                 bound = bound_old-1
             iteration += 1
 
@@ -126,6 +127,7 @@ class CollapsedVB(GPy.core.Model):
                     import warnings
                     warnings.warn("Caught LinalgError in setting variational parameters, trying to continue with old parameter settings", LinAlgWarning)
                     self.set_vb_param(phi_old)
+                    step_length /= 2.
                     bound = self.bound()
                     iteration_failed = False
                 iteration += 1


### PR DESCRIPTION
dividing step size by two, when linalg error occurs.
