### PR TITLE
Speeding up omgp

### DIFF
--- a/GPclust/OMGP.py
+++ b/GPclust/OMGP.py
@@ -139,8 +139,8 @@ class OMGP(CollapsedMixture):
 
             for n in range(self.phi.shape[0]):
                 grad_B_inv = np.zeros_like(B_inv)
-                grad_B_inv[n, n] = -self.variance / (self.phi[n, i] ** 2 + 1e-6)
-                grad_Lm[n, i] = 0.5 * np.trace(np.dot(dL_dB, grad_B_inv))
+                grad_B_inv_nonzero = -self.variance / (self.phi[n, i] ** 2 + 1e-6)
+                grad_Lm[n, i] = 0.5 * dL_dB[n, n] * grad_B_inv_nonzero
 
         grad_phi = grad_Lm + self.mixing_prop_bound_grad() + self.Hgrad
 

--- a/GPclust/OMGP.py
+++ b/GPclust/OMGP.py
@@ -133,12 +133,12 @@ class OMGP(CollapsedMixture):
             I = np.eye(self.N)
 
             B_inv = np.diag(1. / ((self.phi[:, i] + 1e-6) / self.variance))
-            alpha = np.linalg.solve(K + B_inv, self.Y)
+            # alpha = np.linalg.solve(K + B_inv, self.Y)
             K_B_inv = pdinv(K + B_inv)[0]
+            alpha = np.dot(K_B_inv, self.Y)
             dL_dB = tdot(alpha) - K_B_inv
 
             for n in range(self.phi.shape[0]):
-                grad_B_inv = np.zeros_like(B_inv)
                 grad_B_inv_nonzero = -self.variance / (self.phi[n, i] ** 2 + 1e-6)
                 grad_Lm[n, i] = 0.5 * dL_dB[n, n] * grad_B_inv_nonzero
 

--- a/GPclust/OMGP.py
+++ b/GPclust/OMGP.py
@@ -192,10 +192,10 @@ class OMGP(CollapsedMixture):
         plt.scatter(self.X, self.Y, c=self.phi[:, gp_num], cmap=cm.RdBu, vmin=0., vmax=1., lw=0.5)
         plt.colorbar(label='GP {} assignment probability'.format(gp_num))
 
-        GPy.plotting.matplot_dep.Tango.reset()
+        GPy.plotting.Tango.reset()
 
         for i in range(self.phi.shape[1]):
-            col = GPy.plotting.matplot_dep.Tango.nextMedium()
+            col = GPy.plotting.Tango.nextMedium()
             plt.fill_between(XX[:, 0],
                              YY_mu[:, i] - 2 * np.sqrt(YY_var[:, i]),
                              YY_mu[:, i] + 2 * np.sqrt(YY_var[:, i]),

--- a/GPclust/OMGP.py
+++ b/GPclust/OMGP.py
@@ -133,7 +133,6 @@ class OMGP(CollapsedMixture):
             I = np.eye(self.N)
 
             B_inv = np.diag(1. / ((self.phi[:, i] + 1e-6) / self.variance))
-            # alpha = np.linalg.solve(K + B_inv, self.Y)
             K_B_inv = pdinv(K + B_inv)[0]
             alpha = np.dot(K_B_inv, self.Y)
             dL_dB = tdot(alpha) - K_B_inv
@@ -159,11 +158,12 @@ class OMGP(CollapsedMixture):
         # Predict mean
         # This works but should Cholesky for stability
         B_inv = np.diag(1. / (self.phi[:, i] / self.variance))
-        mu = kx.T.dot(np.linalg.solve((K + B_inv), self.Y))
+        K_B_inv = pdinv(K + B_inv)[0]
+        mu = kx.T.dot(np.dot(K_B_inv, self.Y))
 
         # Predict variance
         kxx = kern.K(Xnew, Xnew)
-        va = self.variance + kxx - kx.T.dot(np.linalg.solve((K + B_inv), kx))
+        va = self.variance + kxx - kx.T.dot(np.dot(K_B_inv, kx))
 
         return mu, va
 

--- a/GPclust/OMGP.py
+++ b/GPclust/OMGP.py
@@ -4,7 +4,8 @@
 import numpy as np
 from .collapsed_mixture import CollapsedMixture
 import GPy
-from GPy.util.linalg import mdot, pdinv, backsub_both_sides, dpotrs, jitchol, dtrtrs, tdot
+from GPy.util.linalg import mdot, pdinv, backsub_both_sides, dpotrs, jitchol, dtrtrs
+from GPy.util.linalg import tdot_numpy as tdot
 from scipy import linalg
 
 class OMGP(CollapsedMixture):


### PR DESCRIPTION
I made some changes to speed up the optimization of the mixture parameters and the prediction.

I never realized np.linalg.solve was so slow before!

It doesn't seem that multiplying with inverse is unstable enough to cause large differences in the inference from before, so it seems fine.
